### PR TITLE
fix for the port param of dns_check function only accept int type input

### DIFF
--- a/saltbroker/broker.py
+++ b/saltbroker/broker.py
@@ -29,7 +29,7 @@ class PubBroker(multiprocessing.Process):
     def __init__(self, opts):
         super(PubBroker, self).__init__()
         self.opts = opts
-        self.opts['master_ip'] = salt.utils.dns_check(self.opts['master'], self.opts['publish_port'])
+        self.opts['master_ip'] = salt.utils.dns_check(self.opts['master'], int(self.opts['publish_port']))
 
     def run(self):
         '''
@@ -85,7 +85,7 @@ class RetBroker(multiprocessing.Process):
     def __init__(self, opts):
         super(RetBroker, self).__init__()
         self.opts = opts
-        self.opts['master_ip'] = salt.utils.dns_check(self.opts['master'], self.opts['ret_port'])
+        self.opts['master_ip'] = salt.utils.dns_check(self.opts['master'], int(self.opts['ret_port']))
 
     def run(self):
         '''


### PR DESCRIPTION
```
# python2.7
Python 2.7.14 (default, Jan 31 2018, 02:12:13)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-18)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import salt.utils
>>> salt.utils.dns_check('salt-master', int('4505'))
'x.x.x.x'
>>> salt.utils.dns_check('salt-master', '4505')
Attempt to resolve address 'mfsmaster' failed. Invalid or unresolveable address
```